### PR TITLE
Fix checkbox colors for new popup

### DIFF
--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -2,7 +2,7 @@
 @name Stylus DeepDark
 @namespace github.com/RaitaroH/Stylus-DeepDark
 @homepageURL https://github.com/RaitaroH/Stylus-DeepDark
-@version 1.1.5
+@version 1.1.6
 @updateURL https://rawgit.com/RaitaroH/Stylus-DeepDark/master/StylusDeepDark.user.css
 @description Stylus dark theme
 @author RaitaroH
@@ -427,6 +427,9 @@
 	{
 		fill: var(--main-color) !important;
 	}
+  .svg-icon.checked{
+    fill: var(--main-background) !important;
+  }
 
 
 	/*History*/


### PR DESCRIPTION
Stylus modified its popup to have SVG checkboxes. Their color was the color of the text, so this overrides that to be the background color, as needed.