### PR TITLE
:new: :arrow_up: add cursor width and color option + bump version

### DIFF
--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -2,7 +2,7 @@
 @name Stylus DeepDark
 @namespace github.com/RaitaroH/Stylus-DeepDark
 @homepageURL https://github.com/RaitaroH/Stylus-DeepDark
-@version 1.3.0
+@version 1.3.1
 @updateURL https://raw.githubusercontent.com/RaitaroH/Stylus-DeepDark/master/StylusDeepDark.user.css
 @description Write thy themes in the dark. May the dark be kinder on thine eyes. (Stylus dark theme)
 @author RaitaroH
@@ -123,6 +123,33 @@
 	"Orange": "#ffede1",
 	"Jisho_夜明け":  "#986E3F"
 }
+@var select cursorWidth 'Cursor Width' {
+	"Slim 1px": "1px",
+	"Wider 2px": "2px",
+	"Wider+ 3px": "3px",
+	"Block 7px": "7px"
+}
+@var select cursorColor 'Cursor Color' {
+	"DeepDark": "#00adee",
+	"BreezeDark": "#3DAEE9",
+	"Vertex Dark": "#4080fb",
+	"Arc Dark": "#5294E2",
+	"Firefox Dark": "#5675B9",
+	"Firefox57": "#4080FB",
+	"Discord": "#7289DA",
+	"YouTubeDark": "#E52117",
+	"Mint-Y-Dark": "#9AB87C",
+	"9anime": "#723f8c",
+	"Black&White": "#ffffff",
+	"Yellow_petrocompletions": "#FFC700",
+	"Yellow2": "#FFC700",
+	"Ubuntu_grey": "#EF7847",
+	"Ubuntu_purple": "#EF7847",
+	"Orange": "#ff6905",
+	"Jisho_夜明け": "#EF7D6C",
+	"Terminal": "#04f911",
+	"White": "#fff"
+}
 
 ==/UserStyle== */
 @-moz-document regexp("moz-extension://.*"), regexp("chrome-extension://.*") {
@@ -131,7 +158,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.2.9*/
+/*1.3.1*/
 
 	/*Main color variables*/
 	:root
@@ -145,6 +172,10 @@
 		--dimer-text: /*[[dimerText]]*/;
 
 		--shadow: 0 1px 0.5px rgba(0,0,0,0.13);
+
+		/*Cursor width and color*/
+		--cursor-width: /*[[cursorWidth]]*/;
+		--cursor-color: /*[[cursorColor]]*/;
 
 		/*DeepDark colors*/
 		/*
@@ -749,4 +780,11 @@
 		fill: var(--main-color) !important;
 	}
 
+
+	/*Cursor width and color*/
+	.CodeMirror div.CodeMirror-cursor
+	{
+		border-left-width: var(--cursor-width) !important;
+		border-color: var(--cursor-color) !important;
+	}
 }


### PR DESCRIPTION
Comes in handy to people who find the default 1px wide hard to see.

![cursor-width](https://user-images.githubusercontent.com/31389848/40877771-1a65e04e-667e-11e8-89dc-db0b212e48c1.gif)

Do you know if its possible to have spinboxes instead of drop down options for the width?

