### PR TITLE
Fix hotkey info dialog plus some improvements

### DIFF
--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -426,6 +426,7 @@
 	#header
 	{
 		border-color: var(--main-background) !important;
+		white-space: nowrap !important;
 	}
 	#header summary h2:hover
 	{

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -2,7 +2,7 @@
 @name Stylus DeepDark
 @namespace github.com/RaitaroH/Stylus-DeepDark
 @homepageURL https://github.com/RaitaroH/Stylus-DeepDark
-@version 1.3.1
+@version 1.3.2
 @updateURL https://raw.githubusercontent.com/RaitaroH/Stylus-DeepDark/master/StylusDeepDark.user.css
 @description Write thy themes in the dark. May the dark be kinder on thine eyes. (Stylus dark theme)
 @author RaitaroH
@@ -158,7 +158,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.3.1*/
+/*1.3.2*/
 
 	/*Main color variables*/
 	:root

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -347,6 +347,15 @@
 		--dimer-text: #986E3F;
 		*/
 	}
+	html
+	{
+		text-rendering: optimizeLegibility !important;
+		-webkit-font-smoothing: antialiased !important;
+	}
+	html.newUI .entry.odd
+	{
+		background-color: rgba(0, 0, 0, .138)!important;
+	}
 	#hotkey-info mark
 	{
 		background:  var(--main-background) !important;

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -347,7 +347,18 @@
 		--dimer-text: #986E3F;
 		*/
 	}
-
+	#hotkey-info mark
+	{
+		background:  var(--main-background) !important;
+		border: 1px solid var(--main-color) !important;
+		color: var(--main-color) !important;
+	}
+	#hotkey-info[data-active],
+	#hotkey-info > div
+	{
+		background: var(--main-background) !important;
+		border: transparent !important;
+	}
 	#stylus-edit, body, html, #notes, #header, .CodeMirror, #actions
 	{
 		background-color: var(--main-background) !important;


### PR DESCRIPTION
https://github.com/RaitaroH/Stylus-DeepDark/commit/38dd245b79d141825d6efbf621f92698663a1435 fixes the hotkey dialog

before and after
![before-fix](https://user-images.githubusercontent.com/31389848/40880912-c5f9055c-66b1-11e8-96c2-f0eb9eb15a2e.PNG) ![after-fix](https://user-images.githubusercontent.com/31389848/40880913-c7f38166-66b1-11e8-9db9-69a13795e0c8.PNG)

https://github.com/RaitaroH/Stylus-DeepDark/commit/b6286906f1907d1217850ef93049cb84c99af8f1 fixes a niggling dumpling it wraps the option names:
before and after
![after-fix](https://user-images.githubusercontent.com/31389848/40880936-75299ab4-66b2-11e8-8817-5b220bfcedb0.PNG) ![before-fix](https://user-images.githubusercontent.com/31389848/40880937-7541bd10-66b2-11e8-877a-98fbdc08c681.PNG)

The other are just small improvements.



