### PR TITLE
Color review

### DIFF
--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -177,13 +177,12 @@
 		--cursor-width: /*[[cursorWidth]]*/;
 		--cursor-color: /*[[cursorColor]]*/;
 
-		/*Disable all color*/
-		--disable-all: #d62929;
-		/*Warning color*/
-		--warning: #f33;
-		/*No match regex*/
-		--no-match: #d99b45;
-		/* Odd entry background*/
+		/* These are must have static colors */
+		/*Disable all color/warning exact match from Stylus Turn all Styles off */
+		--warning-disable-all: #d62929;
+		/*No match regex ( This is --main-color from petrocompletions*/
+		--no-match: #FFC700;
+		/* Odd entry background (sorry --shadow is too light for this purpose)*/
 		--odd-entry-background: rgba(0, 0, 0, .16);
 
 		/*DeepDark colors*/
@@ -588,7 +587,7 @@
 	}
 	.regexp-report details[data-type="invalid"]
 	{
-		color: var(--warning) !important;
+		color: var(--warning-disable-all) !important;
 	}
 
 
@@ -848,7 +847,7 @@
 	/* This fixes the disable all checkbox background being too bright on hover	 */
 	#disableAll:hover
 	{
-		border-color: var(--disable-all) !important;
+		border-color: var(--warning-disable-all) !important;
 		background-color: var(--second-background) !important;
 	}
 

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -179,9 +179,9 @@
 
 		/* These are must have static colors */
 		/*Disable all color/warning exact match from Stylus Turn all Styles off */
-		--warning-disable-all: #d62929;
+		--warning-disable-all: #DA4453;
 		/*No match regex ( This is --main-color from petrocompletions*/
-		--no-match: #FFC700;
+		--no-match: #FDBC4B;
 		/* Odd entry background (sorry --shadow is too light for this purpose)*/
 		--odd-entry-background: rgba(0, 0, 0, .16);
 

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -2,7 +2,7 @@
 @name Stylus DeepDark
 @namespace github.com/RaitaroH/Stylus-DeepDark
 @homepageURL https://github.com/RaitaroH/Stylus-DeepDark
-@version 1.3.5
+@version 1.3.6
 @updateURL https://raw.githubusercontent.com/RaitaroH/Stylus-DeepDark/master/StylusDeepDark.user.css
 @description Write thy themes in the dark. May the dark be kinder on thine eyes. (Stylus dark theme)
 @author RaitaroH
@@ -158,7 +158,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.3.5*/
+/*1.3.6*/
 
 	/*Main color variables*/
 	:root


### PR DESCRIPTION
The `--disable-all: #d62929;` has to stay really. :dove: :peace_symbol: 

![capture](https://user-images.githubusercontent.com/31389848/40885704-7edba0ea-6723-11e8-831c-18cfdadd47ee.PNG)

The `--no-match: #FFC700;` I swapped instead of `#d99b45` for an already existing color from `/*Yellow (colors from petrocompletions)*/` https://github.com/RaitaroH/Stylus-DeepDark/blob/54ce71c81f7a810b6744e619005147ace9c8d45c/StylusDeepDark.user.css#L299-L301

`#FFC700` in use
![capture](https://user-images.githubusercontent.com/31389848/40885921-5f93b700-6727-11e8-82e5-b77ddf1d974f.PNG)

:warning: Im happy to use the --main-color for both match and no match regex. 

The `--odd-entry-background: rgba(0, 0, 0, .16);` I tried using the already existing `--shadow` https://github.com/RaitaroH/Stylus-DeepDark/blob/54ce71c81f7a810b6744e619005147ace9c8d45c/StylusDeepDark.user.css#L174
Buts on one dialog its used it really doesn't show with some backgrounds, especially the really dark ones.

![capture](https://user-images.githubusercontent.com/31389848/40885961-ad177bc4-6727-11e8-9d29-364b0572106d.PNG)

As you can see `rgba(0, 0, 0, .16)` in this dialog is already too subtle but any darker it its too much for other dialog.

Ive lost the other shade of red, because OK in this instance there is no justification for adding another red, Sorry for rocking the boat :+1: 

So really Ive added two colors which is better.

And you decide. I'll leave this to you.

Again have a nice Sunday and thank you for your time. :dove: :peace_symbol: :1st_place_medal: :hugs: 



