### PR TITLE
A few more fixes and a revert.

### DIFF
--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -626,6 +626,11 @@
 	{
 		background-color: var(--odd-entry-background) !important;
 	}
+	/* fix: dont allow UserCSS option names to wrap */
+	.config-name
+	{
+		white-space: nowrap !important;
+	}
 
 	/*Buttons*/
 	#save-button, #beautify, #cancel-button, #from-mozilla, #to-mozilla,

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -9,7 +9,7 @@
 @license GNU-V3.0
 
 @preprocessor uso
-@var select mainColor 'Main color' {
+@var select mainColor 'Main color:' {
 	"DeepDark": "#00adee",
 	"BreezeDark": "#3DAEE9",
 	"Vertex Dark": "#4080fb",
@@ -28,7 +28,7 @@
 	"Orange": "#ff6905",
 	"Jisho_夜明け": "#EF7D6C"
 }
-@var select mainBackground 'Main background color' {
+@var select mainBackground 'Main background color:' {
 	"DeepDark": "#111111",
 	"BreezeDark": "#232629",
 	"Vertex Dark": "#2B2B2C",
@@ -47,7 +47,7 @@
 	"Orange": "#0a0400",
 	"Jisho_夜明け": "#332222"
 }
-@var select secondBackground 'Second background color' {
+@var select secondBackground 'Second background color:' {
 	"DeepDark": "#181818",
 	"BreezeDark": "#2a2e32",
 	"Vertex Dark": "#353638",
@@ -66,7 +66,7 @@
 	"Orange": "#0e0702",
 	"Jisho_夜明け": "#2A1B1B"
 }
-@var select hoverBackground 'Hover background color' {
+@var select hoverBackground 'Hover background color:' {
 	"DeepDark": "#232323",
 	"BreezeDark": "#31363b",
 	"Vertex Dark": "#515254",
@@ -85,7 +85,7 @@
 	"Orange": "#110903",
 	"Jisho_夜明け": "#863B2F"
 }
-@var select mainText 'Main text color' {
+@var select mainText 'Main text color:' {
 	"DeepDark": "#eff0f1",
 	"BreezeDark": "#eff0f1",
 	"Vertex Dark": "#F3F3F5",
@@ -104,7 +104,7 @@
 	"Orange": "#fff9f5",
 	"Jisho_夜明け": "#EFB26C"
 }
-@var select dimmerText 'Secondary text color' {
+@var select dimmerText 'Secondary text color:' {
 	"DeepDark": "#CCCCCC",
 	"BreezeDark": "#bdc3c7",
 	"Vertex Dark": "#AEAFB0",
@@ -123,13 +123,13 @@
 	"Orange": "#ffede1",
 	"Jisho_夜明け": "#986E3F"
 }
-@var select cursorWidth 'Cursor width' {
+@var select cursorWidth 'Cursor width:' {
 	"Slim 1px": "1px",
 	"Wider 2px": "2px",
 	"Wider+ 3px": "3px",
 	"Block 7px": "7px"
 }
-@var select cursorColor 'Cursor color' {
+@var select cursorColor 'Cursor color:' {
 	"DeepDark": "#00adee",
 	"BreezeDark": "#3DAEE9",
 	"Vertex Dark": "#4080fb",

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -632,6 +632,12 @@
 		white-space: nowrap !important;
 	}
 
+	/* editor line tweak */
+	#sections > div:not(:first-of-type)
+	{
+		border-top: 2px solid var(--second-background) !important;
+	}
+
 	/*Buttons*/
 	#save-button, #beautify, #cancel-button, #from-mozilla, #to-mozilla,
 	#editor\.keyMap, #editor\.theme, #editor\.matchHighlight, #editor\.tabSize,

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -698,13 +698,18 @@
 		color: var(--main-text) !important;
 	}
 
-	/*Search*/
-	.CodeMirror-search-match, .CodeMirror-search, .cm-searching
+	/*Search
+	Cannot enable  .cm-searching for time being, this causes issues with find/replace
+	in fact I dont think any of these selectors below have any effect*/
+	.CodeMirror-search-match, .CodeMirror-search/*, .cm-searching*/
 	{
 		background: var(--main-color) !important;
 		border-color: var(--main-color) !important;
-		color: var(--main-text) !important;
 	}
+	/*
+	Have to disable .cm-searching:after because this causes
+	a horizontal scroll and the background behind is lighter than the previous
+	I suspect this is an existing bug with this style
 	.cm-searching:after
 	{
 		content: "" !important;
@@ -713,7 +718,7 @@
 		position: absolute !important;
 		width: 100% !important;
 		margin-top: 17px!important;
-	}
+	} */
 	.CodeMirror-dialog, .CodeMirror-dialog input
 	{
 		background: var(--hover-background) !important;

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -789,9 +789,11 @@
 	{
 		outline-color: var(--main-color);
 	}
+	/* fix: Stylus remove that unsightly white border in input */
 	body:not(#stylus-options) input
 	{
 		background-color: var(--second-background);
+		border: 1px solid var(--hover-background);
 		color: var(--main-text);
 	}
 	fieldset, [style-id], .disabled

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -2,7 +2,7 @@
 @name Stylus DeepDark
 @namespace github.com/RaitaroH/Stylus-DeepDark
 @homepageURL https://github.com/RaitaroH/Stylus-DeepDark
-@version 1.3.8
+@version 1.3.9
 @updateURL https://raw.githubusercontent.com/RaitaroH/Stylus-DeepDark/master/StylusDeepDark.user.css
 @description Write thy themes in the dark. May the dark be kinder on thine eyes. (Stylus dark theme)
 @author RaitaroH
@@ -158,7 +158,7 @@
 
 /*GNU General Public License v3.0*/
 
-/*1.3.8*/
+/*1.3.9*/
 
 	/*Main color variables*/
 	:root

--- a/StylusDeepDark.user.css
+++ b/StylusDeepDark.user.css
@@ -492,12 +492,14 @@
 	div.CodeMirror span.CodeMirror-matchingbracket
 	{
 		color: var(--main-color) !important;
+		-webkit-text-fill-color: var(--main-color) !important;
 		font-weight: 900 !important;
 		outline: none !important;
 	}
 	div.CodeMirror span.CodeMirror-nonmatchingbracket
 	{
 		color: var(--warning-disable-all) !important;
+		 -webkit-text-fill-color: var(--warning-disable-all) !important;
 		font-weight: 900 !important;
 	}
 


### PR DESCRIPTION
With https://github.com/RaitaroH/Stylus-DeepDark/commit/786e99eed3ac611b5bea6515fcfeb8c3d13a5fad I introduced a non wrap for `.config-name` and added colons to option name strings with https://github.com/RaitaroH/Stylus-DeepDark/commit/aacd6bcfcf5f64e8d8b11d97d80d10777f34cee0

:notebook: Unless there is some UserCSS style with silly long option names this change should not cause any issues. 

:warning: I can revert https://github.com/RaitaroH/Stylus-DeepDark/commit/aacd6bcfcf5f64e8d8b11d97d80d10777f34cee0 if not wanted.

This how it looks.

![settings config](https://user-images.githubusercontent.com/31389848/40995771-fbd38452-68f7-11e8-9088-022b0bfdf418.PNG)

If not wanted I can revert https://github.com/RaitaroH/Stylus-DeepDark/commit/aacd6bcfcf5f64e8d8b11d97d80d10777f34cee0 if not desired. No big deal.

In https://github.com/RaitaroH/Stylus-DeepDark/commit/771791172df38b3c879150ffb4baf5a6a1a4c0e5 the input box white border is gone. 

before
![before-fix](https://user-images.githubusercontent.com/31389848/40996246-42f9dc4a-68f9-11e8-9ece-d9ae2739dbfd.PNG)

after
![after-fix](https://user-images.githubusercontent.com/31389848/40996254-4984d916-68f9-11e8-8f0e-5ea2d5a255ad.PNG)

However this is marked as Stylish on chrome fixes, but the selector matches Stylus and I dont care about Stylish to test.

The rest is pretty standard with the exception of https://github.com/RaitaroH/Stylus-DeepDark/commit/5aafdfbfafbbd8eeca6af37235b1016ee5ab91de which reverts https://github.com/RaitaroH/Stylus-DeepDark/commit/f9d5afc5fbbb0b4b37d75a4fcc81de799f665680 since the style has too many issues that I cant be bothered to fix in order to enable this, sorry.
Expect a bug report for that.

